### PR TITLE
Fixed Syntax Error

### DIFF
--- a/manifests/task.pp
+++ b/manifests/task.pp
@@ -79,6 +79,6 @@ define check_run::task (
     require => Exec[$task_name],
   }
   anchor{"check_run::task::${title}::end":
-    require => Exec [ "${touch_cmd_path} ${root_dir}/${task_name}"],
+    require => Exec["${touch_cmd_path} ${root_dir}/${task_name}"],
   }
 }


### PR DESCRIPTION
```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Syntax error at '[' at .../check_run/manifests/task.pp:82:21
```
